### PR TITLE
1D fits now only use template fits with positive amplitude

### DIFF
--- a/lite.py
+++ b/lite.py
@@ -158,7 +158,7 @@ def amps_errs(profs,temp_fname):
     # WEIRD STUFF (background subtraction)
     #plt.plot(bg_subtract/max(bg_subtract),':b',std_div/max(std_div),'--r')
     #plt.show()
-    return amps,errs
+    return np.asarray(amps), np.asarray(errs)
 
 # NEED TO INCORPORATE ERRORS!!!
 def fit_1d_bp(offs,amps,errs):
@@ -190,6 +190,7 @@ def get_bp(scan_fname,temp_fname,direction,dr=0.1333):
     # Is this necessary? Uses the template to determine, given some threshold.
     #on_inds, off_inds = on_off(model_fname,nbin,test=0)
     ii,ee = amps_errs(profs,temp_fname)
+    
 
     # ***  Probably need a cos(dec) correction for offsets_arcmin...!  ***
     # 1=Dec, 0=RA
@@ -207,9 +208,9 @@ def get_bp(scan_fname,temp_fname,direction,dr=0.1333):
     bp_vals, bp_errs = fit_1d_bp(offs,ii,ee)
     #plt.errorbar(offs,ii,yerr=ee,fmt='o',capsize=3)
     #plt.plot(offs,gaussian_beam(offs,bp_vals[0],bp_vals[1]),'--r')
-    #print bp_vals,bp_errs
+    print bp_vals,bp_errs
     resids = ii-gaussian_beam(offs,bp_vals[0],bp_vals[1])
-    R_std = np.std(resids)
+    R_std = np.std(resids[ii>0])
     
     #print "Offset    Err:"
     #for oset, err, amp in zip(offs,ee,ii): print oset,err, amp

--- a/lite.py
+++ b/lite.py
@@ -129,7 +129,7 @@ def amps_errs(profs,temp_fname):
     for i,p in enumerate(profs):
         off_pulse_ints = p[off_inds]
         off_mean, off_std = np.mean(off_pulse_ints), np.std(off_pulse_ints)
-        print off_mean,off_std,max(p)
+        #print off_mean,off_std,max(p)
         p -= off_mean
         #bg_subtract.append(off_mean)
         #std_div.append(off_std)
@@ -164,7 +164,9 @@ def amps_errs(profs,temp_fname):
 def fit_1d_bp(offs,amps,errs):
     amp_guess = np.max(amps)-np.min(amps)
     loc_guess = offs[np.argmax(amps)]
-    popt,pcov = curve_fit(gaussian_beam,offs,amps,p0=[amp_guess,loc_guess]) #,sigma=errs,absolute_sigma=True)
+    errs = np.asarray(errs)
+    amps = np.asarray(amps)
+    popt,pcov = curve_fit(gaussian_beam,offs[amps>0],amps[amps>0],p0=[amp_guess,loc_guess],sigma=errs[amps>0],absolute_sigma=True)
     perr = np.sqrt(np.diag(pcov))
     return popt, perr 
 
@@ -205,13 +207,19 @@ def get_bp(scan_fname,temp_fname,direction,dr=0.1333):
     bp_vals, bp_errs = fit_1d_bp(offs,ii,ee)
     #plt.errorbar(offs,ii,yerr=ee,fmt='o',capsize=3)
     #plt.plot(offs,gaussian_beam(offs,bp_vals[0],bp_vals[1]),'--r')
-    print bp_vals,bp_errs
+    #print bp_vals,bp_errs
     resids = ii-gaussian_beam(offs,bp_vals[0],bp_vals[1])
     R_std = np.std(resids)
-
+    
+    #print "Offset    Err:"
+    #for oset, err, amp in zip(offs,ee,ii): print oset,err, amp
+    
+    plt.figure(0)
     plt.errorbar(offs,ii/R_std,yerr=ee/R_std,fmt='o',capsize=3)
     plt.plot(offs,gaussian_beam(offs,bp_vals[0],bp_vals[1])/R_std,'--r')
-
+    plt.figure(1)
+    plt.errorbar(offs,resids, yerr=ee/R_std,fmt='o',capsize=3)
+    plt.plot(offs,[0]*len(offs),'--r')
     plt.show()
 
 

--- a/localize.py
+++ b/localize.py
@@ -5,6 +5,8 @@ import matplotlib.pyplot as plt
 from scipy.optimize import curve_fit, minimize
 from psr_utils import gaussian_profile
 from sys import argv
+from astropy.coordinates import SkyCoord
+from astropy import units as u
 
 #From gaussian_beam
 def gaussian_beam(rr,amp,offset,fwhm=36.0,obsfreq=350.0):
@@ -224,7 +226,7 @@ def get_bpo(pfd_fname,model_fname,dr=0.666,mode="snr",nsubints=None):
 
     pf = prepfold.pfd(pfd_fname)
     pf.dedisperse()
-
+    start_coords = SkyCoord(pf.rastr, pf.decstr, frame="icrs", unit = (u.hourangle, u.deg))
     # BEST WAY TO DO THIS?? 
     nsub    = pf.npart
     nchan   = 1
@@ -240,7 +242,9 @@ def get_bpo(pfd_fname,model_fname,dr=0.666,mode="snr",nsubints=None):
         profs = pf.combine_profs(newsubints,nchan)
 
     elif nsub<nsubints:
+	newsubints = nsub
         print "Cannot scrunch to %d subints since original file has %d subints." % (nsubints,nsub)
+	print "Using %d subints.\n" % (newsubints)
 
     else: newsubints = nsub
   
@@ -289,7 +293,7 @@ def usage():
     print "Usage: python localize.py"
     print "            -dr [drift rate (arcmin/s)]"
     print "             -t [template filename]"
-    print "             -m [mode (??)]"
+    print "             -m [mode (see below)]"
     print "          -nsub [# subints]"
     print "           -pfd [filename]"
     print "        -noplot ...to turn off plotting."
@@ -327,7 +331,7 @@ if __name__ == "__main__":
         elif arg in ["-mode","-m"]:
             mode = args[i+1]
 
-        # does this default to # existing after prepfold?
+        # Defaults to # existing after prepfold.
         elif arg == "-nsub":
             nsub = int(args[i+1])
 
@@ -341,5 +345,5 @@ if __name__ == "__main__":
 
     x = get_bpo(pfd_fname, template_fname, dr=driftrate, mode=mode, nsubints=nsub)
     x.fit_bp()
-
+    
     if make_plot: x.plot_fit()


### PR DESCRIPTION
The 1D fit from curve_fit now only uses positive amplitude data to do the fits and ignores the others. To do this, I converted some of the lists to numpy arrays. I also changed the calculation of the std of the residuals to only include data used in the fit (i.e. positive amplitude data). Lastly, I added a residual plot for diagnostics.